### PR TITLE
Add base url for RSS links to work properly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ tagline: Just a bunch of hackers doing what we find fun.
 description: Just a bunch of hackers doing what we find fun. 
 
 # fill in the protocol & hostname for your site, e.g., 'https://username.github.io'
-url: ''
+url: 'https://blacksunhackers.club'
 
 github:
   username: BlacksunLabs # change to your github username


### PR DESCRIPTION
Adding the site base url to our generator config. This should result in the correct absolute URLs being generated in RSS.xml, as opposed to the current relative URLs which do not work in many feed readers. 